### PR TITLE
Simplify the signature of one of the checks

### DIFF
--- a/src/main/scala/com/ubirch/niomon/healthcheck/HealthCheckServer.scala
+++ b/src/main/scala/com/ubirch/niomon/healthcheck/HealthCheckServer.scala
@@ -170,11 +170,8 @@ object Checks {
     CheckResult(name, success, payload)
   }
 
-  def kafka(name: String, kafkaControl: Option[Control], connectionCountMustBeNonZero: Boolean): (String, CheckerFn) = (name, { implicit ec =>
-    kafkaControl
-      .map(_.metrics)
-      .getOrElse(Future.successful(Map[MetricName, Metric]()))
-      .map(processKafkaMetrics(name, _, connectionCountMustBeNonZero))
+  def kafka(name: String, kafkaControl: Control, connectionCountMustBeNonZero: Boolean): (String, CheckerFn) = (name, { implicit ec =>
+    kafkaControl.metrics.map(processKafkaMetrics(name, _, connectionCountMustBeNonZero))
   })
 
   def kafka(name: String, producer: Producer[_, _], connectionCountMustBeNonZero: Boolean): (String, CheckerFn) = (name, { () =>


### PR DESCRIPTION
This was used in niomon-foundation, and was refactored so the option isn't needed anymore