### PR TITLE
UP-1119 #comment Adding exposing stop method for jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ubirch.niomon</groupId>
     <artifactId>health-check</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/scala/com/ubirch/niomon/healthcheck/JettyServer.scala
+++ b/src/main/scala/com/ubirch/niomon/healthcheck/JettyServer.scala
@@ -21,6 +21,8 @@ class JettyServer(api: HealthCheckApi, docs: OpenApi, port: Int) extends StrictL
     server.start()
   }
 
+  def stop(): Unit = server.stop()
+
   def join(): Unit = server.join()
 
   private def addSwagger(openApi: OpenApi, swaggerPrefix: String): Unit = {


### PR DESCRIPTION
I would like to have the stop method from the jetty server be exposed so that it can be called from the clients in case there is a life cycle hook